### PR TITLE
Add E2E orchestration nested tracing

### DIFF
--- a/src/DurableOrchestrator/Activities/BaseActivity.cs
+++ b/src/DurableOrchestrator/Activities/BaseActivity.cs
@@ -1,0 +1,46 @@
+using DurableOrchestrator.Models;
+
+namespace DurableOrchestrator.Activities;
+
+/// <summary>
+/// Defines the base class for all activity classes.
+/// </summary>
+public abstract class BaseActivity(string activityName)
+{
+    protected readonly Tracer Tracer = TracerProvider.Default.GetTracer(activityName);
+
+    protected TelemetrySpan StartActiveSpan(string name, IObservableContext? input = default)
+    {
+        return input != default ? Tracer.StartActiveSpan(name, SpanKind.Internal, ExtractTracingContext(input)) : Tracer.StartActiveSpan(name);
+    }
+
+    protected void InjectTracingContext(IObservableContext activityInput, SpanContext spanContext)
+    {
+        Propagators.DefaultTextMapPropagator.Inject(
+            new PropagationContext(spanContext, Baggage.Current),
+            activityInput.ObservableProperties,
+            (props, key, value) =>
+            {
+                props ??= new Dictionary<string, object>();
+                props.TryAdd(key, value);
+            });
+    }
+
+    protected SpanContext ExtractTracingContext(IObservableContext activityInput)
+    {
+        var propagationContext = Propagators.DefaultTextMapPropagator.Extract(
+            default,
+            activityInput.ObservableProperties,
+            (props, key) =>
+            {
+                if (!props.TryGetValue(key, out var value) || value.ToString() is null)
+                {
+                    return [];
+                }
+
+                return [value.ToString()];
+            });
+
+        return new SpanContext(propagationContext.ActivityContext);
+    }
+}

--- a/src/DurableOrchestrator/GlobalUsings.cs
+++ b/src/DurableOrchestrator/GlobalUsings.cs
@@ -7,3 +7,6 @@ global using Microsoft.Azure.Functions.Worker.Http;
 global using Microsoft.DurableTask;
 global using Microsoft.DurableTask.Client;
 global using Microsoft.Extensions.Logging;
+global using OpenTelemetry;
+global using OpenTelemetry.Trace;
+global using OpenTelemetry.Context.Propagation;

--- a/src/DurableOrchestrator/KeyVault/KeyVaultActivities.cs
+++ b/src/DurableOrchestrator/KeyVault/KeyVaultActivities.cs
@@ -1,27 +1,30 @@
 using Azure.Security.KeyVault.Secrets;
+using DurableOrchestrator.Activities;
+using DurableOrchestrator.Models;
 using DurableOrchestrator.Observability;
-using OpenTelemetry.Trace;
 
 namespace DurableOrchestrator.KeyVault;
 
 [ActivitySource(nameof(KeyVaultActivities))]
-public class KeyVaultActivities(SecretClient client, ILogger<KeyVaultActivities> log)
+public class KeyVaultActivities(SecretClient client, ILogger<KeyVaultActivities> log) : BaseActivity(nameof(KeyVaultActivities))
 {
-    private readonly Tracer _tracer = TracerProvider.Default.GetTracer(nameof(KeyVaultActivities));
-
     private const string DefaultSecretValue = "N/A";
 
-    [Function(nameof(GetSecretFromKeyVault))]
     /// <summary>
     /// Retrieves a single secret from Azure Key Vault. If the secret is not found, a default value is returned. This method logs the outcome of the operation and handles exceptions by logging them and rethrowing.
     /// </summary>
-    /// <param name="secretName">The name of the secret to retrieve.</param>
+    /// <param name="input">The activity input containing the name of the secret to retrieve.</param>
     /// <param name="executionContext">The function execution context for logging and other execution-related functionalities.</param>
     /// <returns>The value of the secret, or a default value if the secret is not found.</returns>
     /// <exception cref="ArgumentException">Thrown when the secret name is null or whitespace.</exception>
-    public async Task<string> GetSecretFromKeyVault([ActivityTrigger] string secretName, FunctionContext executionContext)
+    [Function(nameof(GetSecretFromKeyVault))]
+    public async Task<string> GetSecretFromKeyVault(
+        [ActivityTrigger] KeyVaultRequest input,
+        FunctionContext executionContext)
     {
-        using var span = _tracer.StartActiveSpan(nameof(GetSecretFromKeyVault));
+        using var span = StartActiveSpan(nameof(GetSecretFromKeyVault), input);
+
+        var secretName = input.SecretName;
 
         if (string.IsNullOrWhiteSpace(secretName))
         {
@@ -50,17 +53,20 @@ public class KeyVaultActivities(SecretClient client, ILogger<KeyVaultActivities>
         }
     }
 
-    [Function(nameof(GetMultipleSecretsFromKeyVault))]
     /// <summary>
     /// Retrieves multiple secrets from Azure Key Vault based on a list of secret names. Each secret's retrieval is attempted, and if not found, a default value is returned for it. The method logs the outcome of each attempt.
     /// </summary>
-    /// <param name="secretNames">A list of secret names to retrieve.</param>
+    /// <param name="input">The activity input containing a list of secret names to retrieve.</param>
     /// <param name="executionContext">The function execution context for logging and other execution-related functionalities.</param>
     /// <returns>A list containing the values of the retrieved secrets, or default values for those not found.</returns>
-    public async Task<List<string>> GetMultipleSecretsFromKeyVault([ActivityTrigger] List<string> secretNames, FunctionContext executionContext)
+    [Function(nameof(GetMultipleSecretsFromKeyVault))]
+    public async Task<List<string>> GetMultipleSecretsFromKeyVault(
+        [ActivityTrigger] KeyVaultRequest input,
+        FunctionContext executionContext)
     {
-        using var span = _tracer.StartActiveSpan(nameof(GetMultipleSecretsFromKeyVault));
+        using var span = StartActiveSpan(nameof(GetMultipleSecretsFromKeyVault), input);
 
+        var secretNames = input.SecretNames ?? throw new ArgumentException("Secret names must not be null.");
         var secretsValues = new List<string>();
 
         foreach (var secretName in secretNames)

--- a/src/DurableOrchestrator/Models/BlobStorageInfo.cs
+++ b/src/DurableOrchestrator/Models/BlobStorageInfo.cs
@@ -1,8 +1,10 @@
 namespace DurableOrchestrator.Models;
-public class BlobStorageInfo
+
+public class BlobStorageInfo : IObservableContext
 {
     [JsonPropertyName("storageAccountName")]
     public string StorageAccountName { get; set; } = string.Empty;
+
     [JsonPropertyName("blobName")]
     public string BlobName { get; set; } = string.Empty;
 
@@ -11,8 +13,13 @@ public class BlobStorageInfo
 
     [JsonPropertyName("blobUri")]
     public string BlobUri { get; set; } = string.Empty;
+
     [JsonPropertyName("content")]
     public string Content { get; set; } = string.Empty;
+
     [JsonPropertyName("buffer")]
     public byte[] Buffer { get; set; } = Array.Empty<byte>();
+
+    [JsonPropertyName("observableProperties")]
+    public Dictionary<string, object> ObservableProperties { get; set; } = new();
 }

--- a/src/DurableOrchestrator/Models/IObservableContext.cs
+++ b/src/DurableOrchestrator/Models/IObservableContext.cs
@@ -1,0 +1,12 @@
+﻿namespace DurableOrchestrator.Models;
+
+/// <summary>
+/// Defines an interface for sharing the context of an observable sequence through activities.
+/// </summary>
+public interface IObservableContext
+{
+    /// <summary>
+    /// Gets or sets the properties storing the context.
+    /// </summary>
+    Dictionary<string, object> ObservableProperties { get; set; }
+}

--- a/src/DurableOrchestrator/Models/KeyVaultRequest.cs
+++ b/src/DurableOrchestrator/Models/KeyVaultRequest.cs
@@ -1,0 +1,13 @@
+namespace DurableOrchestrator.Models;
+
+public class KeyVaultRequest : IObservableContext
+{
+    [JsonPropertyName("secretName")]
+    public string? SecretName { get; set; }
+
+    [JsonPropertyName("secretNames")]
+    public IEnumerable<string>? SecretNames { get; set; }
+
+    [JsonPropertyName("observableProperties")]
+    public Dictionary<string, object> ObservableProperties { get; set; } = new();
+}

--- a/src/DurableOrchestrator/Models/TextAnalyticRequest.cs
+++ b/src/DurableOrchestrator/Models/TextAnalyticRequest.cs
@@ -1,10 +1,13 @@
 namespace DurableOrchestrator.Models;
 
-public class TextAnalyticsRequest
+public class TextAnalyticsRequest : IObservableContext
 {
     [JsonPropertyName("operationTypes")]
-    public List<string> OperationTypes { get; set; } = new List<string>(); // e.g., ["sentiment", "keyPhrases", "languageDetection"]
+    public List<string>? OperationTypes { get; set; } = new List<string>(); // e.g., ["sentiment", "keyPhrases", "languageDetection"]
 
     [JsonPropertyName("textsToAnalyze")]
     public string TextsToAnalyze { get; set; } = string.Empty;
+
+    [JsonPropertyName("observableProperties")]
+    public Dictionary<string, object> ObservableProperties { get; set; } = new();
 }

--- a/src/DurableOrchestrator/Models/WorkFlowInput.cs
+++ b/src/DurableOrchestrator/Models/WorkFlowInput.cs
@@ -1,8 +1,7 @@
 namespace DurableOrchestrator.Models;
 
-public class WorkFlowInput
+public class WorkFlowInput : IObservableContext
 {
-
     [JsonPropertyName("name")]
     public string Name { get; set; } = string.Empty;
 
@@ -14,10 +13,13 @@ public class WorkFlowInput
 
     [JsonPropertyName("sourceBlobStorageInfo")]
     public BlobStorageInfo? SourceBlobStorageInfo { get; set; }
-    
+
     [JsonPropertyName("targetBlobStorageInfo")]
     public BlobStorageInfo? TargetBlobStorageInfo { get; set; }
 
     [JsonPropertyName("textAnalyticsRequests")]
-    public List<TextAnalyticsRequest>? TextAnalyticsRequests { get; set; } = new List<TextAnalyticsRequest>();
+    public List<TextAnalyticsRequest>? TextAnalyticsRequests { get; set; } = new();
+
+    [JsonPropertyName("observableProperties")]
+    public Dictionary<string, object> ObservableProperties { get; set; } = new();
 }

--- a/src/DurableOrchestrator/Observability/ObservabilityExtensions.cs
+++ b/src/DurableOrchestrator/Observability/ObservabilityExtensions.cs
@@ -5,7 +5,6 @@ using Microsoft.Extensions.Hosting;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
-using OpenTelemetry.Trace;
 
 namespace DurableOrchestrator.Observability;
 

--- a/src/DurableOrchestrator/Workflows/BaseWorkflow.cs
+++ b/src/DurableOrchestrator/Workflows/BaseWorkflow.cs
@@ -1,45 +1,42 @@
-using OpenTelemetry.Trace;
 using DurableOrchestrator.Models;
 
 namespace DurableOrchestrator.Workflows;
 
-public abstract class BaseWorkflow
+/// <summary>
+/// Initializes a new instance of the BaseWorkflow class with a specified workflow name. It sets up tracing for the workflow using the OpenTelemetry framework.
+/// </summary>
+/// <param name="workflowName">The name of the workflow for which tracing is to be set up.</param>
+public abstract class BaseWorkflow(string workflowName)
 {
-    protected readonly Tracer Tracer;
-    /// <summary>
-    /// Initializes a new instance of the BaseWorkflow class with a specified workflow name. It sets up tracing for the workflow using the OpenTelemetry framework.
-    /// </summary>
-    /// <param name="workflowName">The name of the workflow for which tracing is to be set up.</param>
-    public BaseWorkflow(string workflowName)
-    {
-        Tracer = TracerProvider.Default.GetTracer(workflowName);
-    }
+    protected readonly Tracer Tracer = TracerProvider.Default.GetTracer(workflowName);
 
     /// <summary>
     /// Validates the inputs provided to a workflow. It checks for null values, mandatory fields, and specific conditions that must be met for the workflow to proceed.
     /// </summary>
     /// <param name="workFlowInput">The WorkFlowInput object containing the input data for validation.</param>
     /// <returns>A ValidationResult object containing information about whether the input is valid, and if not, a list of error messages.</returns>
-    protected static ValidationResult ValidateWorkFlowInputs(WorkFlowInput workFlowInput)
+    protected static ValidationResult ValidateWorkFlowInputs(WorkFlowInput? workFlowInput)
     {
         var result = new ValidationResult { IsValid = true };
 
-        if(workFlowInput == null)
+        if (workFlowInput == null)
         {
             result.AddMessage("WorkFlowInput is null. No additional checks where performed.");
             result.IsValid = false;
             return result;
         }
+
         // Source and Target Blobs while marked as optional are required for the workflow to proceed
-        if(string.IsNullOrEmpty(workFlowInput.Name))
+        if (string.IsNullOrEmpty(workFlowInput.Name))
         {
             result.AddMessage("Workflow name is missing.");
-        }            
+        }
+
         if (workFlowInput!.SourceBlobStorageInfo == null)
         {
             result.AddMessage("Source blob storage info is missing.");
             result.IsValid = false;
-        }            
+        }
         else
         {
             if (string.IsNullOrEmpty(workFlowInput.SourceBlobStorageInfo.BlobName))
@@ -47,18 +44,21 @@ public abstract class BaseWorkflow
                 result.AddMessage("Source blob name is missing.");
                 // could be missing - not breaking the validity of the request
             }
+
             if (string.IsNullOrEmpty(workFlowInput.SourceBlobStorageInfo.ContainerName))
             {
                 result.AddMessage("Source container name is missing.");
                 result.IsValid = false;
             }
+
             if (string.IsNullOrEmpty(workFlowInput.SourceBlobStorageInfo.StorageAccountName))
             {
                 result.AddMessage("Source storage account name is missing.");
                 result.IsValid = false;
             }
         }
-        if(workFlowInput.TargetBlobStorageInfo == null)
+
+        if (workFlowInput.TargetBlobStorageInfo == null)
         {
             result.AddMessage("Target blob storage info is missing.");
             result.IsValid = false;
@@ -69,18 +69,21 @@ public abstract class BaseWorkflow
             {
                 result.AddMessage("Target blob name is missing.");
             }
+
             if (string.IsNullOrEmpty(workFlowInput.TargetBlobStorageInfo.ContainerName))
             {
                 result.AddMessage("Target container name is missing.");
                 result.IsValid = false;
             }
+
             if (string.IsNullOrEmpty(workFlowInput.TargetBlobStorageInfo.StorageAccountName))
             {
                 result.AddMessage("Target storage account name is missing.");
                 result.IsValid = false;
             }
         }
-        if(workFlowInput.TextAnalyticsRequests == null || workFlowInput.TextAnalyticsRequests.Count == 0)
+
+        if (workFlowInput.TextAnalyticsRequests == null || workFlowInput.TextAnalyticsRequests.Count == 0)
         {
             result.AddMessage("TextAnalyticsRequests is missing or empty.");
         }
@@ -94,6 +97,7 @@ public abstract class BaseWorkflow
                     result.AddMessage("TextsToAnalyze is missing or empty.");
                     result.IsValid = false;
                 }
+
                 if (request.OperationTypes == null || request.OperationTypes.Count == 0)
                 {
                     result.AddMessage("OperationTypes is missing or empty - what should be done with the text?");
@@ -101,8 +105,10 @@ public abstract class BaseWorkflow
                 }
             }
         }
+
         return result;
     }
+
     /// <summary>
     /// Extracts the workflow input from a JSON-formatted string. It deserializes the request body into a WorkFlowInput object.
     /// </summary>
@@ -112,7 +118,43 @@ public abstract class BaseWorkflow
     protected static WorkFlowInput ExtractInput(string requestBody)
     {
         var workFlowInput = JsonSerializer.Deserialize<WorkFlowInput>(requestBody) ??
-                    throw new ArgumentException("The request body is not a valid WorkFlowInput.", nameof(requestBody));
+                            throw new ArgumentException("The request body is not a valid WorkFlowInput.",
+                                nameof(requestBody));
         return workFlowInput;
+    }
+
+    protected TelemetrySpan StartActiveSpan(string name, IObservableContext? input = default)
+    {
+        return input != default ? Tracer.StartActiveSpan(name, SpanKind.Internal, ExtractTracingContext(input)) : Tracer.StartActiveSpan(name);
+    }
+
+    protected void InjectTracingContext(IObservableContext activityInput, SpanContext spanContext)
+    {
+        Propagators.DefaultTextMapPropagator.Inject(
+            new PropagationContext(spanContext, Baggage.Current),
+            activityInput.ObservableProperties,
+            (props, key, value) =>
+            {
+                props ??= new Dictionary<string, object>();
+                props.TryAdd(key, value);
+            });
+    }
+
+    protected SpanContext ExtractTracingContext(IObservableContext activityInput)
+    {
+        var propagationContext = Propagators.DefaultTextMapPropagator.Extract(
+            default,
+            activityInput.ObservableProperties,
+            (props, key) =>
+            {
+                if (!props.TryGetValue(key, out var value) || value.ToString() is null)
+                {
+                    return [];
+                }
+
+                return [value.ToString()];
+            });
+
+        return new SpanContext(propagationContext.ActivityContext);
     }
 }

--- a/src/DurableOrchestrator/Workflows/CopyBlobWorkflow.cs
+++ b/src/DurableOrchestrator/Workflows/CopyBlobWorkflow.cs
@@ -1,62 +1,68 @@
-using DurableOrchestrator.Observability;
 using DurableOrchestrator.Models;
-using OpenTelemetry.Trace;
+using DurableOrchestrator.Observability;
+using DurableOrchestrator.Storage;
 
 namespace DurableOrchestrator.Workflows;
 
 [ActivitySource(nameof(CopyBlobWorkflow))]
-public class CopyBlobWorkflow : BaseWorkflow
+public class CopyBlobWorkflow() : BaseWorkflow(nameof(CopyBlobWorkflow))
 {
-    private readonly Tracer _tracer = TracerProvider.Default.GetTracer(nameof(CopyBlobWorkflow));
-    public CopyBlobWorkflow() : base(nameof(CopyBlobWorkflow)) { }
     private const string OrchestrationName = "CopyBlobWorkflow";
     private const string OrchestrationTriggerName = $"{OrchestrationName}_HttpStart";
-    [Function("CopyBlobWorkflow")]
+
     /// <summary>
     /// Orchestrates the process of copying content from a source blob to a target blob. It involves validating the workflow input, retrieving the content of the source blob, and writing that content to the target blob.
     /// </summary>
     /// <param name="context">The orchestration context providing access to workflow-related methods and properties.</param>
     /// <returns>A list of strings representing the orchestration results, which could include validation errors, informational messages, or a success message indicating the completion of the copy operation.</returns>
+    [Function(OrchestrationName)]
     public async Task<List<string>> RunOrchestrator(
         [OrchestrationTrigger] TaskOrchestrationContext context)
     {
-        using var span = _tracer.StartActiveSpan(OrchestrationName);
-
-        var log = context.CreateReplaySafeLogger(OrchestrationName);
-        var orchestrationResults = new List<string>();
         // step 1: obtain input for the workflow
-        var workFlowInput = context.GetInput<WorkFlowInput>();
+        var workFlowInput = context.GetInput<WorkFlowInput>() ??
+                            throw new ArgumentNullException(nameof(context), "WorkFlowInput is null.");
+
+        using var span = StartActiveSpan(OrchestrationName, workFlowInput);
+        var log = context.CreateReplaySafeLogger(OrchestrationName);
+
+        var orchestrationResults = new List<string>();
 
         // step 2: validate the input
-        ValidationResult validationResult = ValidateWorkFlowInputs(workFlowInput!);
+        var validationResult = ValidateWorkFlowInputs(workFlowInput);
         if (!validationResult.IsValid)
         {
-            log.LogError($"CopyBlobWorkflow::WorkFlowInput is invalid. {validationResult.GetValidationMessages()}");
             orchestrationResults.AddRange(validationResult.ValidationMessages);
+            log.LogError($"CopyBlobWorkflow::WorkFlowInput is invalid. {validationResult.GetValidationMessages()}");
             return orchestrationResults; // Exit the orchestration due to validation errors
         }
-        else
-        {
-            orchestrationResults.Add("CopyBlobWorkflow::WorkFlowInput is valid.");
-        }
+
+        orchestrationResults.Add("CopyBlobWorkflow::WorkFlowInput is valid.");
+        log.LogInformation("CopyBlobWorkflow::WorkFlowInput is valid.");
+
         // step 3: get blob content to be copied
-        var blobContent = await context.CallActivityAsync<byte[]>("GetBlobContentAsBuffer", workFlowInput!.SourceBlobStorageInfo);
+        var sourceBlobStorageInfo = workFlowInput.SourceBlobStorageInfo!;
+        InjectTracingContext(sourceBlobStorageInfo, span.Context);
+
+        var blobContent = await context.CallActivityAsync<byte[]>(nameof(BlobStorageActivities.GetBlobContentAsBuffer), sourceBlobStorageInfo);
         log.LogInformation($"CopyBlobWorkflow::Retrieved blob content size: {blobContent?.Length ?? 0} bytes.");
 
-        if(blobContent == null || blobContent.Length == 0)
+        if (blobContent == null || blobContent.Length == 0)
         {
             log.LogError("CopyBlobWorkflow::Blob content is empty or null.");
             orchestrationResults.Add("Blob content is empty or null.");
             return orchestrationResults; // Exit the orchestration due to missing blob content
         }
-        BlobStorageInfo targetBlobStorageInfo = workFlowInput.TargetBlobStorageInfo!;
+
         // step 4: write to another blob
+        var targetBlobStorageInfo = workFlowInput.TargetBlobStorageInfo!;
         targetBlobStorageInfo.Buffer = blobContent;
-        await context.CallActivityAsync<string>("WriteBufferToBlob",targetBlobStorageInfo);
+        InjectTracingContext(targetBlobStorageInfo, span.Context);
+
+        await context.CallActivityAsync<string>(nameof(BlobStorageActivities.WriteBufferToBlob), targetBlobStorageInfo);
         return orchestrationResults;
     }
 
-    [Function(OrchestrationTriggerName)]
     /// <summary>
     /// HTTP-triggered function that starts the blob copy orchestration. It extracts input from the HTTP request body, schedules a new orchestration instance for the copy operation, and returns a response with the status check URL.
     /// </summary>
@@ -64,30 +70,33 @@ public class CopyBlobWorkflow : BaseWorkflow
     /// <param name="starter">The durable task client used to schedule new orchestration instances.</param>
     /// <param name="executionContext">The function execution context for logging and other execution-related functionalities.</param>
     /// <returns>A response with the HTTP status code and the URL to check the orchestration status.</returns>
+    [Function(OrchestrationTriggerName)]
     public async Task<HttpResponseData> HttpStart(
         [HttpTrigger(AuthorizationLevel.Anonymous, "post")]
         HttpRequestData req,
         [DurableClient] DurableTaskClient starter,
         FunctionContext executionContext)
     {
-        using var span = _tracer.StartActiveSpan(OrchestrationTriggerName);
+        using var span = StartActiveSpan(OrchestrationTriggerName);
 
         var log = executionContext.GetLogger(OrchestrationTriggerName);
 
         var requestBody = await req.ReadAsStringAsync();
+
         // Check for an empty request body as a more direct approach
-        
         if (string.IsNullOrEmpty(requestBody))
         {
-             throw new ArgumentException("The request body must not be null or empty.", nameof(req));
-        } 
+            throw new ArgumentException("The request body must not be null or empty.", nameof(req));
+        }
+
         var input = ExtractInput(requestBody);
+        InjectTracingContext(input, span.Context);
 
         // Function input comes from the request content.
-        string instanceId = await starter.ScheduleNewOrchestrationInstanceAsync("CopyBlobWorkflow", input);
+        var instanceId = await starter.ScheduleNewOrchestrationInstanceAsync("CopyBlobWorkflow", input);
 
         log.LogInformation("Started orchestration with ID = '{instanceId}'.", instanceId);
 
-        return starter.CreateCheckStatusResponse(req, instanceId);
+        return await starter.CreateCheckStatusResponseAsync(req, instanceId);
     }
 }

--- a/src/DurableOrchestrator/Workflows/CopyBlobWorkflow.cs
+++ b/src/DurableOrchestrator/Workflows/CopyBlobWorkflow.cs
@@ -93,7 +93,7 @@ public class CopyBlobWorkflow() : BaseWorkflow(nameof(CopyBlobWorkflow))
         InjectTracingContext(input, span.Context);
 
         // Function input comes from the request content.
-        var instanceId = await starter.ScheduleNewOrchestrationInstanceAsync("CopyBlobWorkflow", input);
+        var instanceId = await starter.ScheduleNewOrchestrationInstanceAsync(OrchestrationName, input);
 
         log.LogInformation("Started orchestration with ID = '{instanceId}'.", instanceId);
 

--- a/src/DurableOrchestrator/Workflows/TextAnalyticsWorkflow.cs
+++ b/src/DurableOrchestrator/Workflows/TextAnalyticsWorkflow.cs
@@ -123,7 +123,7 @@ public class TextAnalyticsWorkflow() : BaseWorkflow(nameof(TextAnalyticsWorkflow
         InjectTracingContext(input, span.Context);
 
         // Function input extracted from the request content.
-        var instanceId = await starter.ScheduleNewOrchestrationInstanceAsync("BatchExtractSentiment", input);
+        var instanceId = await starter.ScheduleNewOrchestrationInstanceAsync("TextAnalyticsWorkflow", input);
 
         log.LogInformation("Started orchestration with ID = '{instanceId}'.", instanceId);
 

--- a/src/DurableOrchestrator/Workflows/TextAnalyticsWorkflow.cs
+++ b/src/DurableOrchestrator/Workflows/TextAnalyticsWorkflow.cs
@@ -41,7 +41,7 @@ public class TextAnalyticsWorkflow() : BaseWorkflow(nameof(TextAnalyticsWorkflow
         orchestrationResults.Add("TextAnalyticsWorkflow::WorkFlowInput is valid.");
         log.LogInformation("TextAnalyticsWorkflow::WorkFlowInput is valid.");
 
-        // step 3: 
+        // step 3:
         // call the sentiment analysis activity for each text analytics request - fan-out/fan-in
         var sentimentTasks = new List<Task<string?>>();
         // both workflowinput and textanalyticsrequests are not null - checked above
@@ -123,7 +123,7 @@ public class TextAnalyticsWorkflow() : BaseWorkflow(nameof(TextAnalyticsWorkflow
         InjectTracingContext(input, span.Context);
 
         // Function input extracted from the request content.
-        var instanceId = await starter.ScheduleNewOrchestrationInstanceAsync("TextAnalyticsWorkflow", input);
+        var instanceId = await starter.ScheduleNewOrchestrationInstanceAsync(OrchestrationName, input);
 
         log.LogInformation("Started orchestration with ID = '{instanceId}'.", instanceId);
 

--- a/src/DurableOrchestrator/Workflows/TextAnalyticsWorkflow.cs
+++ b/src/DurableOrchestrator/Workflows/TextAnalyticsWorkflow.cs
@@ -1,45 +1,46 @@
-using DurableOrchestrator.Observability;
+using DurableOrchestrator.AI;
 using DurableOrchestrator.Models;
-using OpenTelemetry.Trace;
+using DurableOrchestrator.Observability;
+using DurableOrchestrator.Storage;
 
 namespace DurableOrchestrator.Workflows;
 
 [ActivitySource(nameof(TextAnalyticsWorkflow))]
-public class TextAnalyticsWorkflow : BaseWorkflow
+public class TextAnalyticsWorkflow() : BaseWorkflow(nameof(TextAnalyticsWorkflow))
 {
-    private readonly Tracer _tracer = TracerProvider.Default.GetTracer(nameof(TextAnalyticsWorkflow));
-    public TextAnalyticsWorkflow() : base(nameof(TextAnalyticsWorkflow)) { }
     private const string OrchestrationName = "TextAnalyticsWorkflow";
     private const string OrchestrationTriggerName = $"{OrchestrationName}_HttpStart";
 
-    [Function("BatchExtractSentiment")]
     /// <summary>
     /// Orchestrates the sentiment analysis process by validating input, performing sentiment analysis on each text analytics request (fan-out/fan-in pattern), and saving the analysis results to blob storage.
     /// </summary>
     /// <param name="context">The orchestration context providing access to workflow-related methods and properties.</param>
     /// <returns>A list of strings representing the orchestration results, which could include validation errors, informational messages, or the success message indicating the completion of sentiment analysis and data persistence.</returns>
+    [Function(OrchestrationName)]
     public async Task<List<string>> RunOrchestrator(
         [OrchestrationTrigger] TaskOrchestrationContext context)
     {
-        using var span = _tracer.StartActiveSpan(OrchestrationName);
-
-        var log = context.CreateReplaySafeLogger(OrchestrationName);
-        var orchestrationResults = new List<string>();
         // step 1: obtain input for the workflow
-        var workFlowInput = context.GetInput<WorkFlowInput>();
+        var workFlowInput = context.GetInput<WorkFlowInput>() ??
+                            throw new ArgumentNullException(nameof(context), "WorkFlowInput is null.");
+
+        using var span = StartActiveSpan(OrchestrationName, workFlowInput);
+        var log = context.CreateReplaySafeLogger(OrchestrationName);
+
+        var orchestrationResults = new List<string>();
 
         // step 2: validate the input
-        ValidationResult validationResult = ValidateWorkFlowInputs(workFlowInput!);
+        var validationResult = ValidateWorkFlowInputs(workFlowInput!);
         if (!validationResult.IsValid)
         {
-            log.LogError($"BatchExtractSentiment::WorkFlowInput is invalid. {validationResult.GetValidationMessages()}");
             orchestrationResults.AddRange(validationResult.ValidationMessages); // some of the 'errors' are not really errors, but just informational messages
+            log.LogError($"TextAnalyticsWorkflow::WorkFlowInput is invalid. {validationResult.GetValidationMessages()}");
             return orchestrationResults; // Exit the orchestration due to validation errors
         }
-        else
-        {
-            orchestrationResults.Add("BatchExtractSentiment::WorkFlowInput is valid.");
-        }
+
+        orchestrationResults.Add("TextAnalyticsWorkflow::WorkFlowInput is valid.");
+        log.LogInformation("TextAnalyticsWorkflow::WorkFlowInput is valid.");
+
         // step 3: 
         // call the sentiment analysis activity for each text analytics request - fan-out/fan-in
         var sentimentTasks = new List<Task<string?>>();
@@ -47,7 +48,8 @@ public class TextAnalyticsWorkflow : BaseWorkflow
         foreach (var request in workFlowInput!.TextAnalyticsRequests!)
         {
             // Fan-out: start a task for each text analytics request
-            var task = context.CallActivityAsync<string?>(("GetSentiment"), request);
+            InjectTracingContext(request, span.Context);
+            var task = context.CallActivityAsync<string?>(nameof(TextAnalyticsActivities.GetSentiment), request);
             sentimentTasks.Add(task);
         }
         // Fan-in: Wait for all sentiment analysis tasks to complete
@@ -59,10 +61,10 @@ public class TextAnalyticsWorkflow : BaseWorkflow
             sentiments.Add(await task); // Here, you could handle nulls or errors as needed
         }
 
-        orchestrationResults.Add("BatchExtractSentiment::Sentiment analysis completed.");
+        orchestrationResults.Add("TextAnalyticsWorkflow::Sentiment analysis completed.");
         // create a new file, and save the sentiments gathered from the text analytics together with the original text
-        AnalysisResults analysisResults = new AnalysisResults();
-        for (int i = 0; i < workFlowInput!.TextAnalyticsRequests!.Count; i++)
+        var analysisResults = new AnalysisResults();
+        for (var i = 0; i < workFlowInput!.TextAnalyticsRequests!.Count; i++)
         {
             analysisResults.Results.Add(new TextSentimentResult
             {
@@ -76,7 +78,7 @@ public class TextAnalyticsWorkflow : BaseWorkflow
         // first define where to write the file
         var targetBlobStorageInfo = workFlowInput.TargetBlobStorageInfo!;
 
-        if (blobContent == null || blobContent.Length == 0)
+        if (blobContent.Length == 0)
         {
             log.LogError("BatchExtractSentiment::Blob content is empty or null.");
             orchestrationResults.Add("Blob content is empty or null.");
@@ -85,11 +87,12 @@ public class TextAnalyticsWorkflow : BaseWorkflow
 
         // step 4: write to another blob
         targetBlobStorageInfo.Buffer = System.Text.Encoding.UTF8.GetBytes(blobContent);
-        await context.CallActivityAsync<string>("WriteBufferToBlob",targetBlobStorageInfo);
+        InjectTracingContext(targetBlobStorageInfo, span.Context);
+        await context.CallActivityAsync<string>(nameof(BlobStorageActivities.WriteBufferToBlob), targetBlobStorageInfo);
+
         return orchestrationResults;
     }
 
-    [Function(OrchestrationTriggerName)]
     /// <summary>
     /// HTTP-triggered function that starts the text analytics orchestration. It extracts input from the HTTP request body, schedules a new orchestration instance for sentiment analysis, and returns a response with the status check URL.
     /// </summary>
@@ -97,30 +100,33 @@ public class TextAnalyticsWorkflow : BaseWorkflow
     /// <param name="starter">The durable task client used to schedule new orchestration instances.</param>
     /// <param name="executionContext">The function execution context for logging and other execution-related functionalities.</param>
     /// <returns>A response with the HTTP status code and the URL to check the orchestration status.</returns>
+    [Function(OrchestrationTriggerName)]
     public async Task<HttpResponseData> HttpStart(
         [HttpTrigger(AuthorizationLevel.Anonymous, "post")]
         HttpRequestData req,
         [DurableClient] DurableTaskClient starter,
         FunctionContext executionContext)
     {
-        using var span = _tracer.StartActiveSpan(OrchestrationTriggerName);
+        using var span = StartActiveSpan(OrchestrationTriggerName);
 
         var log = executionContext.GetLogger(OrchestrationTriggerName);
 
         var requestBody = await req.ReadAsStringAsync();
-        // Check for an empty request body as a more direct approach
 
+        // Check for an empty request body as a more direct approach
         if (string.IsNullOrEmpty(requestBody))
         {
             throw new ArgumentException("The request body must not be null or empty.", nameof(req));
         }
+
         var input = ExtractInput(requestBody);
+        InjectTracingContext(input, span.Context);
 
         // Function input extracted from the request content.
-        string instanceId = await starter.ScheduleNewOrchestrationInstanceAsync("BatchExtractSentiment", input);
+        var instanceId = await starter.ScheduleNewOrchestrationInstanceAsync("BatchExtractSentiment", input);
 
         log.LogInformation("Started orchestration with ID = '{instanceId}'.", instanceId);
 
-        return starter.CreateCheckStatusResponse(req, instanceId);
+        return await starter.CreateCheckStatusResponseAsync(req, instanceId);
     }
 }


### PR DESCRIPTION
This PR introduces the following changes:

- Add `BaseActivity` class with implementation for injecting and extracting OpenTelemetry context from caller
- Update `BaseWorkflow` class with implementation for injecting and extracting OpenTelemetry context from caller
- Update all orchestrators and activities to implement adding context before sending requests, and extract context when running to update active span with caller span details (parent)
- Update `CallActivityAsync()` methods to use `nameof()` for accurate name referencing
- Update all orchestrators to match for consistency with setup and naming

The following is now the output seen by tracing showing the original orchestrator trigger caller, through the orchestrator, to the activities. This shows a complete end-to-end timeline for a workflow.

![image](https://github.com/yodobrin/DurableOrchestrator/assets/13505183/b0b097ee-1a9e-47f6-9d47-b22cc673eee1)
