### PR TITLE
Add independent tracing providers

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -217,6 +217,10 @@ module functionApp './compute/function-app.bicep' = {
           value: 'DefaultEndpointsProtocol=https;AccountName=${storageAccount.outputs.name};EndpointSuffix=${environment().suffixes.storage};AccountKey=${storageAccountRef.listKeys().keys[0].value}'
         }
         {
+          name: 'MANAGED_IDENTITY_CLIENT_ID'
+          value: managedIdentity.outputs.clientId
+        }
+        {
           name: 'KEY_VAULT_URL'
           value: keyVault.outputs.uri
         }

--- a/src/DurableOrchestrator/AI/TextAnalyticsActivities.cs
+++ b/src/DurableOrchestrator/AI/TextAnalyticsActivities.cs
@@ -6,7 +6,11 @@ using DurableOrchestrator.Observability;
 namespace DurableOrchestrator.AI;
 
 [ActivitySource(nameof(TextAnalyticsActivities))]
-public class TextAnalyticsActivities(TextAnalyticsClient client, ILogger<TextAnalyticsActivities> log) : BaseActivity(nameof(TextAnalyticsActivities))
+public class TextAnalyticsActivities(
+    TextAnalyticsClient client,
+    ObservabilitySettings observabilitySettings,
+    ILogger<TextAnalyticsActivities> log)
+    : BaseActivity(nameof(TextAnalyticsActivities), observabilitySettings)
 {
     /// <summary>
     /// Analyzes the sentiment of the provided text using Azure AI Text Analytics.
@@ -56,11 +60,13 @@ public class TextAnalyticsActivities(TextAnalyticsClient client, ILogger<TextAna
             log.LogError("Input is null.");
             return false;
         }
+
         if (string.IsNullOrWhiteSpace(input.TextsToAnalyze))
         {
             log.LogError("TextsToAnalyze is null or whitespace.");
             return false;
         }
+
         return true;
     }
 }

--- a/src/DurableOrchestrator/KeyVault/KeyVaultActivities.cs
+++ b/src/DurableOrchestrator/KeyVault/KeyVaultActivities.cs
@@ -6,7 +6,11 @@ using DurableOrchestrator.Observability;
 namespace DurableOrchestrator.KeyVault;
 
 [ActivitySource(nameof(KeyVaultActivities))]
-public class KeyVaultActivities(SecretClient client, ILogger<KeyVaultActivities> log) : BaseActivity(nameof(KeyVaultActivities))
+public class KeyVaultActivities(
+    SecretClient client,
+    ILogger<KeyVaultActivities> log,
+    ObservabilitySettings observabilitySettings)
+    : BaseActivity(nameof(KeyVaultActivities), observabilitySettings)
 {
     private const string DefaultSecretValue = "N/A";
 

--- a/src/DurableOrchestrator/Observability/ObservabilitySettings.cs
+++ b/src/DurableOrchestrator/Observability/ObservabilitySettings.cs
@@ -5,7 +5,7 @@ namespace DurableOrchestrator.Observability;
 /// <summary>
 /// Defines the settings for configuring application observability.
 /// </summary>
-public class ObservabilitySettings(string? applicationInsightsConnectionString)
+public class ObservabilitySettings(string? applicationInsightsConnectionString, string? zipkinEndpointUrl)
 {
     /// <summary>
     /// The configuration key for the Application Insights connection string.
@@ -13,9 +13,19 @@ public class ObservabilitySettings(string? applicationInsightsConnectionString)
     public const string ApplicationInsightsConnectionStringConfigKey = "APPLICATIONINSIGHTS_CONNECTION_STRING";
 
     /// <summary>
+    /// The configuration key for the Zipkin endpoint URL.
+    /// </summary>
+    public const string ZipkinEndpointUrlConfigKey = "ZIPKIN_ENDPOINT_URL";
+
+    /// <summary>
     /// Gets the Application Insights connection string.
     /// </summary>
     public string? ApplicationInsightsConnectionString { get; init; } = applicationInsightsConnectionString;
+
+    /// <summary>
+    /// Gets the Zipkin endpoint URL.
+    /// </summary>
+    public string? ZipkinEndpointUrl { get; init; } = zipkinEndpointUrl;
 
     /// <summary>
     /// Creates a new instance of the <see cref="ObservabilitySettings"/> class from the specified configuration.
@@ -25,6 +35,7 @@ public class ObservabilitySettings(string? applicationInsightsConnectionString)
     public static ObservabilitySettings FromConfiguration(IConfiguration configuration)
     {
         return new ObservabilitySettings(
-            configuration[ApplicationInsightsConnectionStringConfigKey]);
+            configuration[ApplicationInsightsConnectionStringConfigKey],
+            configuration[ZipkinEndpointUrlConfigKey] ?? "http://localhost:9411/api/v2/spans");
     }
 }

--- a/src/DurableOrchestrator/Program.cs
+++ b/src/DurableOrchestrator/Program.cs
@@ -19,7 +19,7 @@ var host = new HostBuilder()
     {
         services.AddSingleton(_ =>
         {
-            var azureCredentials = new DefaultAzureCredential(new DefaultAzureCredentialOptions
+            var credentialOpts = new DefaultAzureCredentialOptions
             {
                 ExcludeEnvironmentCredential = true,
                 ExcludeInteractiveBrowserCredential = true,
@@ -30,9 +30,15 @@ var host = new HostBuilder()
                 ExcludeAzurePowerShellCredential = true,
                 ExcludeWorkloadIdentityCredential = true,
                 CredentialProcessTimeout = TimeSpan.FromSeconds(10)
-            });
+            };
 
-            return azureCredentials;
+            var managedIdentityClientId = builder.Configuration.GetValue<string>("MANAGED_IDENTITY_CLIENT_ID");
+            if (!string.IsNullOrEmpty(managedIdentityClientId))
+            {
+                credentialOpts.ManagedIdentityClientId = managedIdentityClientId;
+            }
+
+            return new DefaultAzureCredential(credentialOpts);
         });
 
         // No changes needed here for KeyVault and Observability

--- a/src/DurableOrchestrator/Storage/BlobStorageActivities.cs
+++ b/src/DurableOrchestrator/Storage/BlobStorageActivities.cs
@@ -8,8 +8,9 @@ namespace DurableOrchestrator.Storage;
 [ActivitySource(nameof(BlobStorageActivities))]
 public class BlobStorageActivities(
     BlobServiceClientsWrapper blobServiceClientsWrapper,
-    ILogger<BlobStorageActivities> log)
-    : BaseActivity(nameof(BlobStorageActivities))
+    ILogger<BlobStorageActivities> log,
+    ObservabilitySettings observabilitySettings)
+    : BaseActivity(nameof(BlobStorageActivities), observabilitySettings)
 {
     /// <summary>
     /// Retrieves the content of a blob as a string. Validates the input before attempting to read the blob's content.

--- a/src/DurableOrchestrator/Workflows/CopyBlobWorkflow.cs
+++ b/src/DurableOrchestrator/Workflows/CopyBlobWorkflow.cs
@@ -5,7 +5,8 @@ using DurableOrchestrator.Storage;
 namespace DurableOrchestrator.Workflows;
 
 [ActivitySource(nameof(CopyBlobWorkflow))]
-public class CopyBlobWorkflow() : BaseWorkflow(nameof(CopyBlobWorkflow))
+public class CopyBlobWorkflow(ObservabilitySettings observabilitySettings)
+    : BaseWorkflow(nameof(CopyBlobWorkflow), observabilitySettings)
 {
     private const string OrchestrationName = "CopyBlobWorkflow";
     private const string OrchestrationTriggerName = $"{OrchestrationName}_HttpStart";
@@ -44,7 +45,8 @@ public class CopyBlobWorkflow() : BaseWorkflow(nameof(CopyBlobWorkflow))
         var sourceBlobStorageInfo = workFlowInput.SourceBlobStorageInfo!;
         InjectTracingContext(sourceBlobStorageInfo, span.Context);
 
-        var blobContent = await context.CallActivityAsync<byte[]>(nameof(BlobStorageActivities.GetBlobContentAsBuffer), sourceBlobStorageInfo);
+        var blobContent = await context.CallActivityAsync<byte[]>(nameof(BlobStorageActivities.GetBlobContentAsBuffer),
+            sourceBlobStorageInfo);
         log.LogInformation($"CopyBlobWorkflow::Retrieved blob content size: {blobContent?.Length ?? 0} bytes.");
 
         if (blobContent == null || blobContent.Length == 0)

--- a/src/DurableOrchestrator/Workflows/WorkflowOrc.cs
+++ b/src/DurableOrchestrator/Workflows/WorkflowOrc.cs
@@ -6,7 +6,8 @@ using DurableOrchestrator.Storage;
 namespace DurableOrchestrator.Workflows;
 
 [ActivitySource(nameof(WorkflowOrc))]
-public class WorkflowOrc() : BaseWorkflow(nameof(WorkflowOrc))
+public class WorkflowOrc(ObservabilitySettings observabilitySettings)
+    : BaseWorkflow(nameof(WorkflowOrc), observabilitySettings)
 {
     private const string OrchestrationName = "WorkflowOrc";
     private const string OrchestrationTriggerName = $"{OrchestrationName}_HttpStart";


### PR DESCRIPTION
This PR introduces the following changes:

- Add independent tracing providers for workflows and activities to render in the Application Insights application map as separate entities.
- Update default Azure credential initialization to explicitly set which managed identity client ID will be used for authentication.

![image](https://github.com/yodobrin/DurableOrchestrator/assets/13505183/40357bb8-63dd-4a68-b8cb-88059d7b9940)
