### PR TITLE
prompt as code

### DIFF
--- a/src/DurableOrchestrator.AzureOpenAI/IDurableOrchestratorPrompts.cs
+++ b/src/DurableOrchestrator.AzureOpenAI/IDurableOrchestratorPrompts.cs
@@ -1,0 +1,6 @@
+namespace DurableOrchestrator.AzureOpenAI;
+public interface IDurableOrchestratorPrompts
+{
+    const string SystemExtractData2Json = "You are an AI assistant that extracts data from documents and returns them as structured JSON objects. Do not return as a code block.";
+    const string UserExtractData2JsonTemplate = "Extract the data from this document. If a value is not present, provide null. Use the following structure: {JsonStructure}";
+}

--- a/src/DurableOrchestrator.Core/BaseWorkflow.cs
+++ b/src/DurableOrchestrator.Core/BaseWorkflow.cs
@@ -3,6 +3,7 @@ using DurableOrchestrator.Core.Observability;
 using Microsoft.DurableTask;
 using Microsoft.DurableTask.Client;
 using OpenTelemetry.Trace;
+using System.Globalization;
 
 namespace DurableOrchestrator.Core;
 
@@ -141,4 +142,15 @@ public abstract class BaseWorkflow(string name)
             ? Tracer.StartActiveSpan(spanName, SpanKind.Internal, context.ExtractObservabilityContext())
             : Tracer.StartActiveSpan(spanName);
     }
+
+
+    protected static string FormatTemplate(string template, Dictionary<string, string> parameters)
+    {
+        foreach (var param in parameters)
+        {
+            template = template.Replace("{" + param.Key + "}", string.Format(CultureInfo.InvariantCulture, "{0}", param.Value));
+        }
+        return template;
+    }
+
 }


### PR DESCRIPTION
Added a base interface to the openai project, this would host generic prompts that could be used by all flows.
to use just base interface prompts, simply add it to the inheritance chain. 
when more prompts are required to a specific workflow, it is advised to use the interface as the base for the specific interface (in most cases it would be created in the same workflow folder or the example folder.
added a format method to the base workflow, the way this should be used, is the formating of the prompt is done before it is passed to the activity. first creating a dictionary:
```
var UserParameters = new Dictionary<string, string>
        {
            { "JsonStructure", JsonSerializer.Serialize(invoiceDataStructure) }
        };
```

then calling the format method:
```FormatTemplate(IDurableOrchestratorPrompts.UserExtractData2JsonTemplate, UserParameters),```
as part of the OpenAICompletionRequest